### PR TITLE
Added ext-bcmath to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
   },
   "require": {
     "php": "^7.1.3",
+    "ext-bcmath": "*",
     "kornrunner/keccak": "1.0",
     "web3p/rlp": "0.2.1",
     "guzzlehttp/guzzle": "6.3",


### PR DESCRIPTION
`bcmul` and other BCMath functions won't work unless `ext-bcmath` is installed.