### PR TITLE
Allow pass to Guzzle  GET  request , string query values

### DIFF
--- a/src/Minter/Library/Http.php
+++ b/src/Minter/Library/Http.php
@@ -33,13 +33,19 @@ Trait Http
      * http get request
      *
      * @param string     $url
-     * @param array|null $parameters
+     * @param array|string|null $parameters
      * @return mixed
      * @throws \Exception
      * @throws GuzzleException
      */
-    protected function get(string $url, array $parameters = null)
+    protected function get(string $url, $parameters = null)
     {
+        if (!is_null($parameters)) {
+          if (!is_array($parameters) && !is_string($parameters)) {
+            throw new \TypeError("$parameters is not of type string or array");
+          }
+        }
+        
         try {
             $response = $this->client->request('GET', $url, [
                 'query' => $parameters


### PR DESCRIPTION
Guzzle client ready to get param query as array or string value.
String params type allow us prepare and send by guzzle , query like 'var[]=2&var[]=1'